### PR TITLE
Adding getHistoryBy functionality to model, ability to add array of strings ,numbers to array data type without model

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,12 @@ const Asset = new Ledger(qldb, 'Assets', {
             allowNull: false,
         },
         hideOwner: {
-            type: DataTypes.BOOL,
+            type: DataTypes.BOOLEAN,
             allowNull: false,
             default: false
         },
         hidePrice: {
-            type: DataTypes.BOOL,
+            type: DataTypes.BOOLEAN,
             allowNull: false,
             default: false
         }
@@ -211,7 +211,21 @@ Search in a linked Ledger
           }, 
     }
 ```
-   
+### Fetching History of Document
+
+````javascript
+    let args = {
+        where:{
+            Name:"Asset1"
+        }
+    }
+    async getHistory(args){
+        let assetHistory = await Asset.getHistoryBy(args);
+        if(assetHistory) return assetHistory;
+        return false
+    }
+````
+
 
 ### Operators
 Since version 1.1.13 operators have been created on the where clause. The available operators are: 'EQ','NE','IN','NOTIN','GT','GTE','LT','LTE'

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Search in a linked Ledger
     }
 ```
 ### Fetching History of Document
+QLDB stores the complete history of every document in a table. You can see all the revisions of document you previously inserted, updated and deleted using ```getHistoryBy()``` method. 
 
 ````javascript
     let args = {

--- a/lib/qldb.base.model.js
+++ b/lib/qldb.base.model.js
@@ -206,6 +206,25 @@ class Ledger {
     };
 
     /**
+     *Find historic changes of a record based on the supplied arguments. if empty object is passed as argument, it returns history of whole table
+     * @param args
+     * @returns {Promise<void>}
+     */
+    async getHistoryBy(args) {
+
+        const results = await this.qldbConnection.getHistory(this.tableName, args);
+
+        return results.map((res) => {
+            const { data } = res;
+            if (data) {
+                Object.assign(res, { data: this.buildModelObject(data) });
+            }
+
+            return res;
+        });
+    };
+
+    /**
      * Gets a document by the document.id in the metadata.
      *
      * @param value
@@ -383,8 +402,12 @@ class Ledger {
                 } else if (Array.isArray(data[fieldName])) {
                     for (const element of  data[fieldName]) {
                         let result = null;
+                        // if the model is not defined in array datatype, it will map the data as is. useful for array of strings, numbers, JSON e.t.c
+                        if (typeof fieldOptions.model === 'undefined') {
+                            result = await this.mapDataToModel(element, fieldOptions, currentDepth, maxDepth, isUpdate);
+                        }
                         // Nested arrays of linked Ledger models
-                        if ((fieldOptions.model.constructor) && (fieldOptions.model.constructor.name.toLowerCase() == 'ledger')) {
+                        else if ((fieldOptions.model.constructor) && (fieldOptions.model.constructor.name.toLowerCase() == 'ledger')) {
                             result = await fieldOptions.model.mapDataToModel(element, fieldOptions.model.model, currentDepth + 1, maxDepth, isUpdate);
                         } else {
                             result = await this.mapDataToModel(element, fieldOptions.model, currentDepth , maxDepth, isUpdate);


### PR DESCRIPTION
*Added: getHistoryBy functionality to model
*Updated: Array Datatype- Ability to add an array of strings, numbers to array data type without model
*updated docs: BOOLEAN datatype typo fix in read me, adding getHistoryBy Example in document